### PR TITLE
Implement function to compute rates

### DIFF
--- a/huracanpy/diags/__init__.py
+++ b/huracanpy/diags/__init__.py
@@ -1,8 +1,9 @@
 """Huracanpy module for tracks diagnostics"""
 
-__all__ = ["track_density", "track_stats", "translation_speed", "lifecycle"]
+__all__ = ["track_density", "track_stats", "translation_speed", "lifecycle", "rate"]
 
 from . import track_density
 from . import track_stats
 from . import translation_speed
 from . import lifecycle
+from .rates import rate

--- a/huracanpy/diags/rates.py
+++ b/huracanpy/diags/rates.py
@@ -1,0 +1,61 @@
+"""
+Module containing functions to compute rates.
+"""
+
+import numpy as np
+import xarray as xr
+
+
+def rate(data, rate_var="slp"):
+    """
+    Function to compute the evolution of a variable over time (rate). In particular, works for intensification and deepening rates.
+
+    Parameters
+    ----------
+    data : xarray.dataset of tracks
+    rate_var : str, optional
+        Variable for which the rate is to be computed (ex: "wind" for intensification rate, "slp" for deepening rate). The default is "slp".
+
+    Returns
+    -------
+    xarray.Dataset
+        Rate. Output is stored for points that correspond to the middle of two consecutive points in the initial dataset.
+        The rate is in <unit>/h, where <unit> is the unit of rate_var.
+    """
+
+    data = data.sortby(["track_id", "time"])
+
+    # Compute rate
+    rate = (data[rate_var].values[1:] - data[rate_var].values[:-1]) / (
+        data.time.values[1:] - data.time.values[:-1]
+    ).astype("timedelta64[h]").astype(int)
+
+    # Output nice dataset
+    t = data.time.values[:-1] + (data.time.values[1:] - data.time.values[:-1]) / 2
+    lon = (data.lon.values[1:] + data.lon.values[:-1]) / 2
+    lat = (data.lat.values[1:] + data.lat.values[:-1]) / 2
+    mask = data.track_id.values[1:] == data.track_id.values[:-1]
+
+    # Transform into clean dataset
+    rate = xr.DataArray(
+        rate, dims="mid_record", coords={"mid_record": np.arange(len(rate))}
+    )
+    lon = xr.DataArray(
+        lon, dims="mid_record", coords={"mid_record": np.arange(len(lon))}
+    )
+    lat = xr.DataArray(
+        lat, dims="mid_record", coords={"mid_record": np.arange(len(lat))}
+    )
+    t = xr.DataArray(t, dims="mid_record", coords={"mid_record": np.arange(len(t))})
+    tid = xr.DataArray(
+        data.track_id[1:],
+        dims="mid_record",
+        coords={"mid_record": np.arange(len(data.track_id[1:]))},
+    )
+
+    ds = xr.Dataset({"rate": rate, "lon": lon, "lat": lat, "time": t, "track_id": tid})
+
+    # Remove values for transition between two tracks
+    return ds.where(
+        mask,
+    )  # drop=True raises an error that I don't understand...

--- a/tests/test_diags/test_rates.py
+++ b/tests/test_diags/test_rates.py
@@ -1,0 +1,15 @@
+import huracanpy
+
+
+def test_translation_speed():
+    data = huracanpy.load(huracanpy.example_csv_file, tracker="csv")
+    deepening_rate = huracanpy.diags.rates.rate(data, "slp")
+    intensification_rate = huracanpy.diags.rates.rate(data, "wind10")
+    assert (
+        deepening_rate.isel(mid_record=0).rate
+        == (data.isel(record=1).slp - data.isel(record=0).slp) / 6
+    )
+    assert (
+        intensification_rate.isel(mid_record=0).rate
+        == (data.isel(record=1).wind10 - data.isel(record=0).wind10) / 6
+    )


### PR DESCRIPTION
The new `rate` function computes the temporal evolution of any variable over the lifetime of storms. It can be used, in particular, to compute intensification and deepening rates. 

It will need to be improved to handle units better. For the moment, I only output a unitless values which is in fact <units>/h, where <units> is the unit of the variable. 
It also takes data as argument instead of individual variables, which is likely not the most varname-agnostic way of doing it. 

