### PR TITLE
Track id netcdf

### DIFF
--- a/huracanpy/_data/_netcdf.py
+++ b/huracanpy/_data/_netcdf.py
@@ -24,11 +24,11 @@ def load(filename, **kwargs):
     for npoints, tr_id in zip(rowsize.data, trajectory_id.data):
         trajectory_id_stretched.extend([tr_id] * npoints)
 
-    dataset[trajectory_id.name] = (sample_dimension, trajectory_id_stretched)
+    dataset["track_id"] = (sample_dimension, trajectory_id_stretched)
     # Keep attributes (including cf_role)
-    dataset[trajectory_id.name].attrs = trajectory_id.attrs
+    dataset["track_id"].attrs = trajectory_id.attrs
 
-    return dataset.drop_vars(rowsize.name)
+    return dataset.drop_vars([trajectory_id.name, rowsize.name])
 
 
 def save(dataset, filename):

--- a/tests/test_huracanpy.py
+++ b/tests/test_huracanpy.py
@@ -40,51 +40,29 @@ def test_load_MIT():
 
 
 @pytest.mark.parametrize(
-    "filename,tracker",
+    "filename, tracker",
     [
         (huracanpy.example_TRACK_file, "TRACK"),
         (huracanpy.example_TRACK_netcdf_file, None),
         (huracanpy.example_csv_file, None),
+        (huracanpy.example_parquet_file, None),
         (huracanpy.example_TE_file, "tempestextremes"),
     ],
 )
-def test_save_netcdf(filename, tracker, tmp_path):
+@pytest.mark.parametrize("extension", ["csv", "nc"])
+def test_save(filename, tracker, extension, tmp_path):
+    if filename == huracanpy.example_TRACK_netcdf_file and extension == "csv":
+        pytest.skip(
+            "The netCDF file has multiple dimensions so fails because converting to a"
+            " dataframe leads to having rows equal to the product of the dimensions"
+            " even though the dimensions cover different variables"
+        )
     data = huracanpy.load(filename, tracker=tracker)
     # Copy the data because save modifies the dataset at the moment
-    huracanpy.save(data.copy(), str(tmp_path / "tmp_file.nc"))
+    huracanpy.save(data.copy(), str(tmp_path / f"tmp_file.{extension}"))
 
     # Reload the data and check it is still the same
-    data_ = huracanpy.load(str(tmp_path / "tmp_file.nc"))
-
-    for var in list(data_.variables) + list(data_.coords):
-        # Work around for xarray inconsistent loading the data as float or double
-        # depending on fill_value and scale_factor
-        # np.testing.assert_allclose doesn't work for datetime64
-        if np.issubdtype(data[var].dtype, np.datetime64):
-            assert (data[var].data == data_[var].data).all()
-        elif data[var].dtype != data_[var].dtype:
-            np.testing.assert_allclose(
-                data[var].data.astype(data_[var].dtype), data_[var].data, rtol=1e-6
-            )
-        else:
-            np.testing.assert_allclose(data[var].data, data_[var].data, rtol=0)
-
-
-@pytest.mark.parametrize(
-    "filename,tracker",
-    [
-        (huracanpy.example_TRACK_file, "TRACK"),
-        (huracanpy.example_csv_file, None),
-        (huracanpy.example_TE_file, "tempestextremes"),
-    ],
-)
-def test_save_csv(filename, tracker, tmp_path):
-    data = huracanpy.load(filename, tracker=tracker)
-    # Copy the data because save modifies the dataset at the moment
-    huracanpy.save(data.copy(), str(tmp_path / "tmp_file.csv"))
-
-    # Reload the data and check it is still the same
-    data_ = huracanpy.load(str(tmp_path / "tmp_file.csv"))
+    data_ = huracanpy.load(str(tmp_path / f"tmp_file.{extension}"))
 
     for var in list(data_.variables) + list(data_.coords):
         # Work around for xarray inconsistent loading the data as float or double

--- a/tests/test_huracanpy.py
+++ b/tests/test_huracanpy.py
@@ -2,7 +2,6 @@ import pytest
 import numpy as np
 
 import huracanpy
-from huracanpy._data._netcdf import _find_trajectory_id
 
 
 def test_load_track():
@@ -27,9 +26,7 @@ def test_load_parquet():
 def test_load_netcdf():
     data = huracanpy.load(huracanpy.example_TRACK_netcdf_file)
     assert len(data.time) == 4580
-    track_id = _find_trajectory_id(data)
-    assert len(track_id) == 4580
-    assert len(np.unique(track_id)) == 86
+    assert len(data.groupby("track_id")) == 86
 
 
 def test_load_tempest():


### PR DESCRIPTION
Take commits from #30 to make CF-netcdf files always load in with a variable named "track_id" and simplify tests for load and save