### PR TITLE
Fix ACE calculation turning Pint back to numpy array

### DIFF
--- a/huracanpy/diags/track_stats.py
+++ b/huracanpy/diags/track_stats.py
@@ -84,7 +84,7 @@ def ace_by_point(wind, threshold=34 * units("knots"), wind_units="m s-1"):
     # TODO - extend preprocess_and_wrap to include this if it is needed for more
     #  functions
     if isinstance(ace_values, xr.DataArray) and isinstance(
-        ace_values.values, pint.Quantity
+        ace_values.data, pint.Quantity
     ):
         ace_values = ace_values.metpy.dequantify()
 

--- a/tests/test_diags/test_track_stats.py
+++ b/tests/test_diags/test_track_stats.py
@@ -8,7 +8,7 @@ def test_ace(tracks_csv):
 
     np.testing.assert_allclose(ace, np.array([3.03623809, 2.21637375, 4.83686787]))
 
-    assert isinstance(ace.values, np.ndarray)
+    assert isinstance(ace.data, np.ndarray)
 
 
 def test_duration():


### PR DESCRIPTION
Use .data rather than .values to check the underlying array in the xarray dataset. `.data` gives the underlying array and `.values` always gives a numpy array