### PR TITLE
Fix geopandas usage

### DIFF
--- a/huracanpy/utils/geography.py
+++ b/huracanpy/utils/geography.py
@@ -75,7 +75,7 @@ def get_basin(lon, lat, convention="WMO", crs=None):
 # Running this on lots of tracks was very slow if the file is reopened every time this
 # is called
 _natural_earth_feature_cache = {
-    f"physical_{key}_0_basin": value.rename_axis("basin")
+    f"physical_{key}_0_basin": value.rename_axis("basin").reset_index()
     for key, value in basins_def.items()
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,13 @@ dependencies = [
     "parse",
     "shapely",
     "pandas",
-    "geopandas",
+    # Issue with newer versions of fiona when using old versions of geopandas
+    # see https://stackoverflow.com/a/78949565/8270394
+    # Normally just specify the newer geopandas, but it does not exist for python3.8
+    # so pin the version of fiona when using python3.8
+    "geopandas>=0.14.4;python_version>='3.9'",
+    "geopandas;python_version<'3.9'",
+    "fiona<=1.9.6;python_version<'3.9'",
     "matplotlib",
     "seaborn",
     "netcdf4",


### PR DESCRIPTION
Having the index named "basin" rather than a column wasn't working for older versions of geopandas