### PR TITLE
Speed up loading track files.

### DIFF
--- a/huracanpy/_data/_TRACK.py
+++ b/huracanpy/_data/_TRACK.py
@@ -65,6 +65,8 @@ def load(filename, calendar=None, variable_names=None):
         open_func = open
 
     output = list()
+    track_id = list()
+    times = list()
     with open_func(filename, "rt") as f:
         # The first lines can contain extra information bounded by two extra lines
         # Just skip to the main header line for now
@@ -118,37 +120,29 @@ def load(filename, calendar=None, variable_names=None):
             # Time is a list because it will hold datetime or cftime objects
             # Other variables are a dictionary mapping variable name to a tuple of
             # (time, data_array) as this is what is passed to xarray.Dataset
-            times = [None] * npoints
-            track_data = {label: ("record", np.zeros(npoints)) for label in var_labels}
 
             # Add track ID as a variable along the record dimension so that it can be used
             # for groupby
-            track_id = np.array([track_info["track_id"]] * npoints)
-            track_data["track_id"] = ("record", track_id)
+            track_id.extend([track_info["track_id"]] * npoints)
 
             # Populate time and data line by line
             for m in range(npoints):
-                line = f.readline().strip().split("&")
-                time, lon, lat, vorticity = line[0].split()
-                times[m] = parse_date(time, calendar=calendar)
-                track_data["lon"][1][m] = float(lon)
-                track_data["lat"][1][m] = float(lat)
-                track_data["vorticity"][1][m] = float(vorticity)
+                line = f.readline().strip()
+                times.append(parse_date(line.split(" ")[0], calendar=calendar))
+                output.append(line.replace("&", " "))
 
-                for i, label in enumerate(var_labels[3:], start=1):
-                    track_data[label][1][m] = float(line[i])
+    output = np.genfromtxt(output)
+    data_vars = {
+        varname: ("record", output[:, i])
+        for i, varname in enumerate(var_labels, start=1)
+    }
+    data_vars["track_id"] = ("record", track_id)
+    data_vars["time"] = ("record", times)
 
-            # Return a dataset for the individual track
-            # Add time separately so xarray can deal with the awkward np.datetime64
-            # format
-            ds = xr.Dataset(track_data)
-            ds["time"] = ("record", times)
-            output.append(ds)
+    ds = xr.Dataset(data_vars=data_vars)
+    ds.track_id.attrs["cf_role"] = "trajectory_id"
 
-    output = xr.concat(output, dim="record")
-    output.track_id.attrs["cf_role"] = "trajectory_id"
-
-    return output
+    return ds
 
 
 def load_tilts(filename, calendar=None, nans=1e25):


### PR DESCRIPTION
Read file as a list and use numpy.genfromtxt to parse all numeric data together. A lot of time previously was spent parsing line by line and also repeatedly concatenating the data with xarray.