### PR TITLE
Allow numpy>=2 

### DIFF
--- a/huracanpy/tc/_ace.py
+++ b/huracanpy/tc/_ace.py
@@ -2,6 +2,7 @@
 Module containing functions to compute ACE
 """
 
+import numpy as np
 from numpy.polynomial.polynomial import Polynomial
 import xarray as xr
 import pint
@@ -275,9 +276,14 @@ def get_pressure_wind_relation(pressure, wind=None, model=None, **kwargs):
             "Need to specify either wind or model to calculate pressure-wind relation"
         )
 
-    wind_from_fit = model(pressure)
+    wind_from_fit = _get_wind_from_model(pressure, model)
 
     return wind_from_fit, model
+
+
+@preprocess_and_wrap(wrap_like="pressure")
+def _get_wind_from_model(pressure, model):
+    return np.array(model(pressure))
 
 
 # Pre-determined pressure-wind relationships

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 description = "A python package for working with various forms of feature tracking data"
 requires-python = ">=3.8, <3.13"
 dependencies = [
-    "numpy<2",
+    "numpy",
     "xarray",
     "cftime",
     "parse",


### PR DESCRIPTION
The application of the polynomial for the pressure wind relation always returns a numpy array with for 2.x, but returns the same type as the input for 1.x. I added the metpy wrapper to this part of the function so it will return xarray if xarray is passed and made sure the result is always a numpy array inside the function so it is consistent across 1.x and 2.x