### PR TITLE
Fix functions for cftime

### DIFF
--- a/huracanpy/utils/time.py
+++ b/huracanpy/utils/time.py
@@ -88,9 +88,15 @@ def get_season(track_id, lat, time, convention="short"):
     # Derive values
     hemi = get_hemisphere(lat)
 
-    time = pd.to_datetime(time)
-    year = time.year
-    month = time.month
+    try:
+        time = pd.to_datetime(time)
+        year = time.year
+        month = time.month
+    except TypeError:
+        # Fix for cftime
+        year = np.array([t.year for t in time])
+        month = np.array([t.month for t in time])
+
     # Store in a dataframe
     df = pd.DataFrame(
         {"hemi": hemi, "year": year, "month": month, "track_id": track_id}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 import datetime
 from collections import namedtuple
 
+import cftime
 import numpy as np
 import xarray as xr
 
@@ -12,6 +13,21 @@ import huracanpy
 @pytest.fixture()
 def tracks_csv():
     return huracanpy.load(huracanpy.example_csv_file)
+
+
+@pytest.fixture()
+def tracks_year():
+    return huracanpy.load(huracanpy.example_year_file)
+
+
+@pytest.fixture()
+def tracks_year_cftime():
+    tracks = huracanpy.load(huracanpy.example_year_file)
+    time = [
+        cftime.datetime(t.dt.year, t.dt.month, t.dt.day, t.dt.hour) for t in tracks.time
+    ]
+    tracks["time"] = ("record", time)
+    return tracks
 
 
 @pytest.fixture()

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -1,11 +1,14 @@
 import numpy as np
+import pytest
 
 import huracanpy
 
 
-def test_seasons():
-    data = huracanpy.load(huracanpy.example_year_file)
-    season = huracanpy.utils.time.get_season(data.track_id, data.lat, data.time)
+@pytest.mark.parametrize(("tracks",), [("tracks_year",), ("tracks_year_cftime",)])
+def test_seasons(tracks, request):
+    tracks = request.getfixturevalue(tracks)
+
+    season = huracanpy.utils.time.get_season(tracks.track_id, tracks.lat, tracks.time)
     assert season.astype(int).min() == 1996
     assert season.astype(int).max() == 1997
     np.testing.assert_approx_equal(season.astype(int).mean(), 1996.09894459, 1e-6)


### PR DESCRIPTION
`get_season` doesn't work when using a cftime calendar because `pandas.to_datetime` can't convert these. I've added a try/except to `get_season` to work around this.