### PR TITLE
Fix readthedocs build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ docs = [
     "nbsphinx",
     "IPython",
     "sphinx-design",
+    "ipykernel"
 ]
 
 [build-system]


### PR DESCRIPTION
Add ipykernel to docs requirements (to allow readthedocs to run the notebooks)