### PR TITLE
Fix accessor behavior

### DIFF
--- a/docs/user_guide/install.rst
+++ b/docs/user_guide/install.rst
@@ -5,6 +5,7 @@ To install the package, you can use ``pip``::
 
     pip install huracanpy
 
-This can fail with older python versions due to issues with installing cartopy through
-pip. If this happens, use conda to install cartopy first
-(e.g. ``conda install -c conda-forge cartopy``), then install huracanpy as normal
+Nota Bene:
+
+#. We support Python 3.8 to 3.12. In particular, Python 1.13 is not currently supported due to one of the dependencies not supporting it. 
+#. The installation may fail due to issues with installing cartopy through pip. If this happens, use conda to install cartopy first (e.g. ``conda install -c conda-forge cartopy``), then install huracanpy as normal.

--- a/huracanpy/_accessor.py
+++ b/huracanpy/_accessor.py
@@ -26,7 +26,7 @@ class HuracanPyDataArrayAccessor:
 @xr.register_dataset_accessor("hrcn")
 class HuracanPyDatasetAccessor:
     def __init__(self, dataset):
-        self._dataset = dataset.copy()
+        self._dataset = dataset
 
     # %% Save
     def save(self, filename):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ docs = [
     "nbsphinx",
     "IPython",
     "sphinx-design",
+    "ipykernel"
 ]
 
 [build-system]


### PR DESCRIPTION
See Issue #75 : A quick and silly fix was to remove the `.copy()` from the initialization of the accessor... 