### PR TITLE
Interp test mac

### DIFF
--- a/docs/dev_guide/setup.md
+++ b/docs/dev_guide/setup.md
@@ -30,7 +30,7 @@ source .venv/bin/activate
 
 Install your copy locally
 ```shell
-python -m pip install -e .[dev,docs]
+python -m pip install -e ".[dev,docs]"
 ```
 
 The "[dev]" argument installs the following optional packages that are useful for

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -16,4 +16,4 @@ def test_interpolate_time(tracks_csv):
     # cf_role="trajectory_id" automatically added when result was saved
     del expected.track_id.attrs["cf_role"]
 
-    xr.testing.assert_identical(result, expected)
+    xr.testing.assert_allclose(result, expected)


### PR DESCRIPTION
Weaker assertion for interpolation tests because results might be different across machines. Hopefully this fixes the failure on a mac (#115)