### PR TITLE
Make kde track density integrate to number of points 

### DIFF
--- a/huracanpy/calc/_density.py
+++ b/huracanpy/calc/_density.py
@@ -17,7 +17,7 @@ def density(lon, lat, method="histogram", bin_size=5, crop=False, function_kws=d
     lat : array_like
         latitude series
     method : str, default="histogram"
-        The method used to calculate the density, currently only "histogram", which
+        The method used to calculate the density, currently "histogram" or "kde", which
         gives a 2d histogram using `np.histogram2d`
     bin_size : int or float, default=5
         When using histogram, defines the size (in degrees) of the bins.
@@ -28,7 +28,7 @@ def density(lon, lat, method="histogram", bin_size=5, crop=False, function_kws=d
     Raises
     ------
     NotImplementedError
-        If method given is not 'histogram'
+        If method given is not 'histogram' or 'kde'
 
     Returns
     -------

--- a/huracanpy/calc/_density.py
+++ b/huracanpy/calc/_density.py
@@ -81,4 +81,5 @@ def _kde(lon, lat, x_mid, y_mid, function_kws):
     # Compute kernel density estimate
     kernel = gaussian_kde([lon, lat], **function_kws)
     # Evaluation kernel along positions
-    return np.reshape(kernel(positions), (len(y_mid), len(x_mid)))
+    H = np.reshape(kernel(positions), (len(y_mid), len(x_mid)))
+    return H * len(lon) / H.sum()


### PR DESCRIPTION
Assuming a desirable property of the track density is that it integrates to the number of points, so that the numbers can be interpreted as an order of magnitude of the number of TC points in a given area, I scaled the output of the kde to integrate to the total number of points. 

The test could therefore be (for any track density method we might implement in the future?) whether the track density integrates to the number of points? 

Note that the function first computes a continuous 2D density, and then interpolates it on the requested grid, so it is not an histogram, and will not yield the exact values of number of points per box.

![image](https://github.com/user-attachments/assets/049c2dcc-0187-4953-bdf6-e793cebab5d5)
![image](https://github.com/user-attachments/assets/08020aca-dcdb-43ab-8dcb-b7576dff14a8)
![image](https://github.com/user-attachments/assets/0c5e6277-e371-4f6e-b610-ef3bbc7c021f)
![image](https://github.com/user-attachments/assets/fb2ff027-a885-46d8-8100-c860a81dac94)
![image](https://github.com/user-attachments/assets/c9fbc207-10f2-4e2f-abd2-e3aa0bd14dce)