### PR TITLE
Fix density with crop=True

### DIFF
--- a/huracanpy/calc/_density.py
+++ b/huracanpy/calc/_density.py
@@ -64,9 +64,41 @@ def density(lon, lat, method="histogram", bin_size=5, crop=False, function_kws=d
         coords={"lon": x_mid, "lat": y_mid},
     )
 
-    if crop:  # Crop the map to where there are non-zero points
-        da = da.where(da > 0)
-        return da.where(~np.isnan(da), drop=True).fillna(0)
+    if crop:
+        # Crop the map to where there are non-zero points
+        has_data = da > 0
+
+        # Keep the band of latitudes between first and lat non-empty row
+        idx_lat = np.where(has_data.any(dim="lon"))[0]
+        da = da.isel(lat=slice(idx_lat[0], idx_lat[-1] + 1))
+
+        # Remove the longest band of consecutively empty longitudes and roll the
+        # longitude coordinate to start just after this band
+        idx_lon = np.where(has_data.any(dim="lat"))[0]
+
+        biggest_gap = np.diff(idx_lon).max()
+
+        # Account for a gap that wraps around
+        outer_gap = idx_lon[0] + len(da.lon) - idx_lon[-1] - 1
+
+        if outer_gap > biggest_gap:
+            da = da.isel(lon=slice(idx_lon[0], idx_lon[-1] + 1))
+        else:
+            idx_gap = np.diff(idx_lon).argmax()
+            # Leftmost point to start of gap
+            da_1 = da.isel(lon=slice(0, idx_lon[idx_gap] + 1))
+            # End of gap to rightmost point
+            da_2 = da.isel(lon=slice(idx_lon[idx_gap + 1], None))
+
+            # Stick the second set of data in from of the first set
+            if lon_range == (-180, 180):
+                da_1 = da_1.assign_coords(lon=da_1.lon + 360)
+            else:
+                da_2 = da_2.assign_coords(lon=da_2.lon - 360)
+
+            da = xr.concat([da_2, da_1], dim="lon")
+
+        return da
     else:
         return da
 

--- a/tests/test_calc/test_track_density.py
+++ b/tests/test_calc/test_track_density.py
@@ -1,6 +1,7 @@
 import pytest
 
 import huracanpy
+import numpy as np
 
 
 @pytest.mark.parametrize("baselon", [-180, 0])
@@ -12,6 +13,12 @@ def test_density(baselon, method, crop):
     assert d.min() == 0.0
     assert d.max() == 43.0
     assert d.sum() == len(data.record)
+
+    # "crop=True" used to cut out any rows/columns with all NaN (no data) but this leads
+    # to non-even spacing in longitude or latitude where it has cut out in between data
+    # Instead, we only want to crop around the outside of the valid data
+    assert (np.diff(d.lon) == 5).all()
+    assert (np.diff(d.lat) == 5).all()
 
 
 def test_track_density_fails():


### PR DESCRIPTION
Only crop empty rows and columns outside an inner box of data. Rather than possible empty rows and columns within the data.

Should fix #151 