### PR TITLE
Trajectory ID

### DIFF
--- a/docs/dev_guide/changelog.md
+++ b/docs/dev_guide/changelog.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v1.5.0
+### Added
 - Update IBTrACS offline subsets to 2024
 - Use more explicit "offline-" prefix for offline IBTrACS subsets by default
+- Calculate track density using line intersections
+- Specify the name of the trajectory ID (track_id) in huracanpy.load if the `cf_role` attribute is not present. This is separate from `rename`
 
 ## v1.4.1
 ### Fixed

--- a/huracanpy/_data/_load.py
+++ b/huracanpy/_data/_load.py
@@ -25,6 +25,9 @@ from . import (
 rename_defaults = dict(
     id="track_id",
     sid="track_id",
+    TRACK_ID="track_id",
+    n_track="track_id",
+    stormID="track_id",
     longitude="lon",
     latitude="lat",
     # Names for MIT netCDF
@@ -40,6 +43,19 @@ rename_defaults = dict(
     rlat="lat",
     sname="name",
 )
+
+trajectory_id_defaults = [
+    # Default name for HuracanPy
+    "track_id",
+    # Expected name for CF netCDF
+    "trajectory_id",
+    # TRACK
+    "TRACK_ID",
+    # MIT netCDF
+    "n_track",
+    # CHAZ
+    "stormID",
+]
 
 pandas_valid_time_labels = [
     "year",
@@ -75,6 +91,7 @@ def load(
     baselon=None,
     infer_track_id=None,
     track_id_prefix=None,
+    trajectory_id=None,
     ibtracs_subset="offline-wmo",
     iris_timestep=timedelta(hours=3),
     tempest_extremes_unstructured=False,
@@ -151,6 +168,17 @@ def load(
         the track_ids to keep them as unique identifiers. See
         :py:func:`huracanpy.concat_tracks` for more details
 
+    trajectory_id : str, optional
+        A CF-compliant netCDF file will have a trajectory ID which is identified by
+        having the attribute `cf_role="trajectory_id"`. This is what is generally
+        referred to as the "track_id" in HuracanPy, but other names are allowed.
+
+        When loading from a non-netCDF file or a netCDF file missing the
+        `cf_role` attribute, HuracanPy tries a few assumed names for the trajectory ID
+        and adds the `cf_role` attribute.
+        If this doesn't work, you need to explicitly pass the name of the trajectory ID
+        here.
+
     ibtracs_subset : str, default="offline-wmo"
         IBTrACS subset. Two offline versions are available:
 
@@ -222,6 +250,12 @@ def load(
     # "rename" second in this dictionary combination
     rename = combine_kws(rename, rename_defaults)
 
+    if trajectory_id is not None:
+        if isinstance(trajectory_id, str):
+            trajectory_id = list(trajectory_id)
+    else:
+        trajectory_id = trajectory_id_defaults
+
     if isinstance(filename, (list, tuple, np.ndarray)):
         # Loop through all the files and open them
         tracks = [
@@ -233,6 +267,7 @@ def load(
                 units=units,
                 baselon=baselon,
                 infer_track_id=infer_track_id,
+                trajectory_id=trajectory_id,
                 ibtracs_subset=ibtracs_subset,
                 iris_timestep=iris_timestep,
                 tempest_extremes_unstructured=tempest_extremes_unstructured,
@@ -253,7 +288,7 @@ def load(
         elif extension == "parquet":
             tracks = _csv.load(filename, load_function=pd.read_parquet, **kwargs)
         elif filename.split(".")[-1] == "nc":
-            tracks = _netcdf.load(filename, **kwargs)
+            tracks = _netcdf.load(filename, trajectory_id, **kwargs)
         else:
             msg = "Source is set to None and file type is not detected"
             raise ValueError(msg)
@@ -279,7 +314,7 @@ def load(
         elif source == "ibtracs":
             tracks = ibtracs.load(ibtracs_subset, filename, **kwargs)
         elif source == "netcdf":
-            tracks = _netcdf.load(filename, **kwargs)
+            tracks = _netcdf.load(filename, trajectory_id, **kwargs)
         elif source in [
             "old_hurdat",
             "ecmwf",
@@ -331,7 +366,9 @@ def load(
     if infer_track_id is not None:
         tracks["track_id"] = inferred_track_id(*[tracks[var] for var in infer_track_id])
 
-    tracks.track_id.attrs["cf_role"] = "trajectory_id"
+    # This will add cf_role="trajectory_id" to the relevant variable if it has not
+    # already been added
+    _trajectory_id = _netcdf._find_trajectory_id(tracks, trajectory_id)
 
     return tracks
 

--- a/huracanpy/_data/_netcdf.py
+++ b/huracanpy/_data/_netcdf.py
@@ -11,11 +11,11 @@ import xarray as xr
 # trajectories to allow us to use groupby() and sel() with track_id to work by
 # individual tracks. So we need to replace the "track_id" or equivalent variable when
 # loading or saving the data
-def load(filename, **kwargs):
+def load(filename, trajectory_id_names, **kwargs):
     dataset = xr.open_dataset(filename, **kwargs)
 
     # Check which type of netCDF we have (2d, ragged, or CSV-like)
-    track_id = _find_trajectory_id(dataset)
+    track_id = _find_trajectory_id(dataset, trajectory_id_names)
     time = dataset.time
 
     if time.dims != track_id.dims:
@@ -31,7 +31,7 @@ def load(filename, **kwargs):
         vars_2d = [var for var in dataset if sorted(dims) == sorted(dataset[var].dims)]
 
         if len(vars_2d) > 0:
-            return as1d(dataset, dims, track_id, vars_2d)
+            return as1d(dataset, dims, vars_2d)
         # Otherwise ragged array
         return stretch_trid(dataset, track_id)
     # Otherwise it is in the CSV format used by huracanpy, so just return the
@@ -41,7 +41,7 @@ def load(filename, **kwargs):
 
 def save(dataset, filename, **kwargs):
     # Find the variable with cf_role=trajectory_id
-    trajectory_id = _find_trajectory_id(dataset)
+    trajectory_id = _find_trajectory_id(dataset, [])
 
     # Get the name of the sample dimension. The name "record" has been used in the load
     # functions, but we don't need to assume that is the name. It may be different when
@@ -83,14 +83,14 @@ def stretch_trid(dataset, trajectory_id):
 
     dataset = dataset.drop_vars([trajectory_id.name, rowsize.name])
 
-    dataset["track_id"] = (sample_dimension, trajectory_id_stretched)
+    dataset[trajectory_id.name] = (sample_dimension, trajectory_id_stretched)
     # Keep attributes (add cf_role if not already there)
-    dataset["track_id"].attrs = trajectory_id.attrs
+    dataset[trajectory_id.name].attrs = trajectory_id.attrs
 
     return dataset
 
 
-def as1d(dataset, dims, track_id, vars_2d):
+def as1d(dataset, dims, vars_2d):
     # Stack 2d dimensions into a record dimension
     dataset = dataset.stack(record=dims)
 
@@ -111,28 +111,10 @@ def as1d(dataset, dims, track_id, vars_2d):
     nans = np.array([np.isnan(dataset[var]) for var in vars_2d_floats]).all(axis=0)
     dataset = dataset.isel(record=np.where(~nans)[0])
 
-    # Add cf role to track_id
-    if track_id.name != "track_id":
-        dataset = dataset.rename({track_id.name: "track_id"})
-
     return dataset
 
 
-_trajectory_id_names = [
-    # Default name for HuracanPy
-    "track_id",
-    # TRACK
-    "TRACK_ID",
-    # MIT netCDF
-    "n_track",
-    # CHAZ
-    "stormID",
-    # IBTrACS netCDF
-    "storm",
-]
-
-
-def _find_trajectory_id(dataset):
+def _find_trajectory_id(dataset, trajectory_id_names):
     # Find the variable with cf_role=trajectory_id
     trajectory_id = [
         dataset[var]
@@ -143,7 +125,7 @@ def _find_trajectory_id(dataset):
 
     if len(trajectory_id) == 1:
         return trajectory_id[0]
-    for name in _trajectory_id_names:
+    for name in trajectory_id_names:
         if name in dataset or name in dataset.dims:
             trajectory_id = dataset[name]
             trajectory_id.attrs["cf_role"] = "trajectory_id"

--- a/huracanpy/_data/track_files.py
+++ b/huracanpy/_data/track_files.py
@@ -95,8 +95,8 @@ def load(filename, variable_names=None):
         else:
             if len(variable_names) != nfields:
                 msg = (
-                    f"Number of variable names given ({len(variable_names)}) does not"
-                    f"match number of fields in file ({len(nfields)})"
+                    f"Number of variable names given ({len(variable_names)}) does not "
+                    f"match number of fields in file ({nfields})"
                 )
                 raise ValueError(msg)
         for n, variable_name in enumerate(variable_names):


### PR DESCRIPTION
Add the option to specify the name of the trajectory ID in `huracanpy.load` for netCDF files missing the `cf_role` attribute. This used to be able to be done by renaming the variable to "track_id", but doesn't work anymore. This way the trajectory ID also is not renamed to "track_id" if that is not wanted.

closes #190 